### PR TITLE
Don't compute iOS shadows on Android and other small changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,15 @@ import { View, Platform } from 'react-native';
 
 export default class ElevatedView extends React.Component {
   render() {
-    let { elevation, style, ...otherProps } = this.props;
-    let iosShadowElevation = {
-      shadowColor: 'black',
-    };
+    const { elevation, style, ...otherProps } = this.props;
+    
+    if(Platform.OS === 'android'){
+      return (<View elevation={elevation} style={style} {...otherProps}>
+	      {this.props.children}
+      </View>);
+    }
+
+    let iosShadowElevation = {};
 
     switch (elevation) {
       case 1:
@@ -58,13 +63,10 @@ export default class ElevatedView extends React.Component {
         break;
     }
 
-    return Platform.select({
-      ios: <View style={[iosShadowElevation, style]} {...otherProps}>
+    iosShadowElevation.shadowColor = 'black';
+
+    return (<View style={[iosShadowElevation, style]} {...otherProps}>
         {this.props.children}
-      </View>,
-      android: <View elevation={elevation} style={style} {...otherProps}>
-        {this.props.children}
-      </View>,
-    });
+      </View>);
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,13 +2,23 @@ import React from 'react';
 import { View, Platform } from 'react-native';
 
 export default class ElevatedView extends React.Component {
+  static propTypes = {
+    //elevation of 0 results in a default View.
+    elevation: React.PropTypes.oneOf([0, 1, 2, 3, 4, 5])
+  }
+  static defaultProps = {
+    elevation: 0
+  }
+
   render() {
     const { elevation, style, ...otherProps } = this.props;
-    
-    if(Platform.OS === 'android'){
-      return (<View elevation={elevation} style={style} {...otherProps}>
-	      {this.props.children}
-      </View>);
+
+    if (Platform.OS === 'android') {
+      return (
+        <View elevation={elevation} style={style} {...otherProps}>
+          {this.props.children}
+        </View>
+      );
     }
 
     let iosShadowElevation = {};
@@ -65,8 +75,10 @@ export default class ElevatedView extends React.Component {
 
     iosShadowElevation.shadowColor = 'black';
 
-    return (<View style={[iosShadowElevation, style]} {...otherProps}>
+    return (
+      <View style={[iosShadowElevation, style]} {...otherProps}>
         {this.props.children}
-      </View>);
+      </View>
+    );
   }
 }


### PR DESCRIPTION
I've reordered the component, so the iOS shadows are completely ignored if it is running on Android.
I've also changed a few `let` to `const`.
I also noticed that the `shadowColor` gets removed as soon as the code enters the switch-block, this is now fixed. As 'black' is the default color this shouldn't change anything at all, just to ensure consistency.

(This is my first ever contribution to an open-source repo, so please speak up if I've done something wrong)