### PR TITLE
Import PropTypes from correct package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { View, Platform } from 'react-native';
 
 export default class ElevatedView extends React.Component {
   static propTypes = {
-    elevation: React.PropTypes.number,
+    elevation: PropTypes.number,
   };
   static defaultProps = {
     elevation: 0


### PR DESCRIPTION
Using React.PropTypes is deprecated (and removed from the latest React, causing a bug if using it).
Import it as it should be done